### PR TITLE
Modernize dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,12 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0|^7.1",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*",
-        "mockery/mockery": "^0.9.5"
+        "php": ">=7.0.0",
+        "laravel/framework": "5.5.*|5.6.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6",
-        "orchestra/testbench": "^3.4",
-        "orchestra/database": "3.4.x-dev"
+        "phpunit/phpunit": "^6.0|^7.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,12 @@
             "Dixie\\EloquentModelFuture\\Tests\\": "tests/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dixie\\EloquentModelFuture\\ServiceProvider"
+            ]
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/tests/Unit/Models/FutureTest.php
+++ b/tests/Unit/Models/FutureTest.php
@@ -68,20 +68,4 @@ class FutureTest extends TestCase
     {
         $this->assertInstanceOf(FutureCollection::class, Future::all());
     }
-
-    public function testItHasAForDateScope()
-    {
-    }
-
-    public function testItHasAUntilDateScope()
-    {
-    }
-
-    public function testItHasAUncommittedScope()
-    {
-    }
-
-    public function testItHasACommittedScope()
-    {
-    }
 }


### PR DESCRIPTION
### About
I felt like the package had fallen a bit behind in regards to version numbers. So in this PR I've set the bar a bit higher.

- [x] Deprecate `L5.2`, `L5.3` and `L5.4`
- [x] Introduce `L5.5` `L5.6`
- [x] Bump PHP version, since `L5.5` requires `>= php7.0`
- [x] Remove empty tests (describing existence of model scopes), since they're heavily backed by other tests and therefore does not need to be implemented.
- [x] Add auto-discovery which was added in Laravel `L5.5`